### PR TITLE
Update cron job to run daily

### DIFF
--- a/.github/workflows/update-helm-index.yml
+++ b/.github/workflows/update-helm-index.yml
@@ -1,9 +1,9 @@
 name: "Update Helm Repository Index"
 on:
   workflow_dispatch:
-  # Each Tuesday, as Inspektor Gadget release are done on Monday, at 4 UTC.
   schedule:
-    - cron: "0 4 * * 2"
+    # Daily at 4 UTC. Usually Inspektor Gadget is released on Monday, but there are exceptions, like bug fix releases.
+    - cron: "0 4 * * *"
 permissions: read-all
 
 jobs:


### PR DESCRIPTION
Similar to https://github.com/inspektor-gadget/website/pull/30 we should run cron job daily to ensure we don't miss any release. 
